### PR TITLE
Designs: use relative path

### DIFF
--- a/Designs/Inverter.sch
+++ b/Designs/Inverter.sch
@@ -23,7 +23,7 @@ C {devices/ipin.sym} 640 -520 0 0 {name=p1 lab=A}
 C {devices/iopin.sym} 740 -590 3 0 {name=p2 lab=VP}
 C {devices/iopin.sym} 740 -440 1 0 {name=p3 lab=VN}
 C {devices/opin.sym} 740 -520 0 0 {name=p4 lab=Y}
-C {silicon-env/share/pdk/gf180mcuC/libs.tech/xschem/symbols/pfet_03v3.sym} 720 -560 0 0 {name=M3
+C {symbols/pfet_03v3.sym} 720 -560 0 0 {name=M3
 L=0.28u
 W=0.22u
 nf=1
@@ -37,7 +37,7 @@ sa=0 sb=0 sd=0
 model=pfet_03v3
 spiceprefix=X
 }
-C {silicon-env/share/pdk/gf180mcuC/libs.tech/xschem/symbols/nfet_03v3.sym} 720 -470 0 0 {name=M4
+C {symbols/nfet_03v3.sym} 720 -470 0 0 {name=M4
 L=0.28u
 W=0.22u
 nf=1

--- a/Designs/TopLevel_oscillator.sch
+++ b/Designs/TopLevel_oscillator.sch
@@ -4,8 +4,8 @@ G {}
 K {}
 V {}
 S {name=TT_MODELS1 only_toplevel=false
-.include /usr/local/google/home/nigelcoburn/MixedSignal/silicon-env/share/pdk/gf180mcuC/libs.tech/ngspice/design.ngspice
-.lib /usr/local/google/home/nigelcoburn/MixedSignal/silicon-env/share/pdk/gf180mcuC/libs.tech/ngspice/sm141064.ngspice typical
+.include $::180MCU_MODELS/design.ngspice
+.lib $::180MCU_MODELS/sm141064.ngspice typical
 
 }
 E {}
@@ -32,7 +32,7 @@ shell display plot_2.svg &
 plot Vin Vout
 .endc"}
 C {devices/code_shown.sym} 330 -110 0 0 {name=TTModel1 only_toplevel=false value="
-.include /usr/local/google/home/nigelcoburn/MixedSignal/silicon-env/share/pdk/gf180mcuC/libs.tech/ngspice/design.ngspice
-.libs /usr/local/google/home/nigelcoburn/MixedSignal/silicon-env/share/pdk/gf180mcuC/libs.tech/ngspice/sm141064.ngspice typical
+.include $::180MCU_MODELS/design.ngspice
+.libs $::180MCU_MODELS/sm141064.ngspice typical
 "
 }

--- a/Designs/spice_incl
+++ b/Designs/spice_incl
@@ -1,4 +1,4 @@
 name=TT_MODELS1 only_toplevel=false
-.include /usr/local/google/home/nigelcoburn/MixedSignal/silicon-env/share/pdk/gf180mcuC/libs.tech/ngspice/design.ngspice
-.libs /usr/local/google/home/nigelcoburn/MixedSignal/silicon-env/share/pdk/gf180mcuC/libs.tech/ngspice/sm141064.ngspice typical
+.include $::180MCU_MODELS/design.ngspice
+.libs $::180MCU_MODELS/sm141064.ngspice typical
 "


### PR DESCRIPTION
- use path relative to `XSCHEM_LIBRARY_PATH` for symbols
- use path relative to `180MCU_MODELS` for models

needs the following workaround on `xschemrc`:
```
sed -i -e 's/ngspice\/models/gf180mcuC\/libs.tech\/ngspice/'   $PDK_ROOT/gf180mcuC/libs.tech/xschem/xschemrc 
```
because of https://github.com/google/globalfoundries-pdk-libs-gf180mcu_fd_pr/issues/96