### PR TITLE
OTA_2stage_macro: add missing verilog blackbox

### DIFF
--- a/OTA_2stage_macro.v
+++ b/OTA_2stage_macro.v
@@ -1,0 +1,10 @@
+(*blackbox*)
+module OTA_2stage_macro (
+    inout vdd,
+    inout vss,
+    output vout,
+    input vin1,
+    input vin2,
+    input vp
+);
+endmodule // OTA_2stage


### PR DESCRIPTION
restore blackbox which was renamed from #23 